### PR TITLE
Fix in tests

### DIFF
--- a/tests/testthat/test-label_from_names.R
+++ b/tests/testthat/test-label_from_names.R
@@ -16,6 +16,6 @@ test_that("empty or missing labels are skipped", {
   out <- label_from_names(df)
 
   labs <- labelled::var_label(out)
-  expect_true(is.null(labs[["x"]]))
-  expect_true(is.null(labs[["y"]]))
+  expect_null(labs[["x"]])
+  expect_null(labs[["y"]])
 })

--- a/tests/testthat/test-label_from_names.R
+++ b/tests/testthat/test-label_from_names.R
@@ -16,6 +16,6 @@ test_that("empty or missing labels are skipped", {
   out <- label_from_names(df)
 
   labs <- labelled::var_label(out)
-  expect_true(is.na(labs[["x"]]))
-  expect_true(labs[["y"]] == "" || is.na(labs[["y"]]))
+  expect_true(is.null(labs[["x"]]))
+  expect_true(is.null(labs[["y"]]))
 })


### PR DESCRIPTION
Hi @amaltawfik 

`var_label()` return NULL if no label. This PR proposes to fix your current tests who are failing.

For your information, I'm in the process of releasing a new version of `labelled`, cf. https://github.com/larmarange/labelled/issues/190

Currently, there is a failure in reverse depencies due to this error in your tests.

Could update your tests and release a new version of `spicy`?

Thanks in advance